### PR TITLE
feat: Playwrightを使用したE2Eテスト環境の構築 #41

### DIFF
--- a/frontend/.github/workflows/playwright.yml
+++ b/frontend/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm install -g pnpm && pnpm install
+    - name: Install Playwright Browsers
+      run: pnpm exec playwright install --with-deps
+    - name: Run Playwright tests
+      run: pnpm exec playwright test
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -39,3 +39,11 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -12,7 +12,7 @@
   },
   "overrides": [
     {
-      "includes": ["**/*.test.*"],
+      "includes": ["**/*.test.*", "**/*.spec.*", "**/tests/**"],
       "linter": {
         "rules": {
           "correctness": {
@@ -20,6 +20,9 @@
           },
           "suspicious": {
             "noEmptyBlockStatements": "off"
+          },
+          "performance": {
+            "useTopLevelRegex": "off"
           }
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.2",
+    "@playwright/test": "^1.56.1",
     "@tailwindcss/postcss": "^4.1.12",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.0",
     "msw": "^2.10.4",
-    "playwright": "^1.55.1",
+    "playwright": "^1.56.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.12",
     "tw-animate-css": "^1.3.7",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./tests",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: "npm run start",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         version: 5.0.3(vite@7.1.5(@types/node@20.19.14)(jiti@2.5.1)(lightningcss@1.30.1))
       '@vitest/browser':
         specifier: ^3.2.4
-        version: 3.2.4(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))(playwright@1.55.1)(vite@7.1.5(@types/node@20.19.14)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)
+        version: 3.2.4(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))(playwright@1.56.1)(vite@7.1.5(@types/node@20.19.14)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
@@ -85,8 +85,8 @@ importers:
         specifier: ^2.10.4
         version: 2.11.2(@types/node@20.19.14)(typescript@5.9.2)
       playwright:
-        specifier: ^1.55.1
-        version: 1.55.1
+        specifier: ^1.56.1
+        version: 1.56.1
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -2258,13 +2258,13 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.55.1:
-    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
+  playwright-core@1.56.1:
+    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.55.1:
-    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
+  playwright@1.56.1:
+    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3751,7 +3751,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.2.4(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))(playwright@1.55.1)(vite@7.1.5(@types/node@20.19.14)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))(playwright@1.56.1)(vite@7.1.5(@types/node@20.19.14)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
@@ -3763,7 +3763,7 @@ snapshots:
       vitest: 3.2.4(@types/node@20.19.14)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))
       ws: 8.18.3
     optionalDependencies:
-      playwright: 1.55.1
+      playwright: 1.56.1
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -3787,7 +3787,7 @@ snapshots:
       tinyrainbow: 2.0.0
       vitest: 3.2.4(@types/node@20.19.14)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))(playwright@1.55.1)(vite@7.1.5(@types/node@20.19.14)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))(playwright@1.56.1)(vite@7.1.5(@types/node@20.19.14)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -5026,11 +5026,11 @@ snapshots:
       exsolve: 1.0.7
       pathe: 2.0.3
 
-  playwright-core@1.55.1: {}
+  playwright-core@1.56.1: {}
 
-  playwright@1.55.1:
+  playwright@1.56.1:
     dependencies:
-      playwright-core: 1.55.1
+      playwright-core: 1.56.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -5601,7 +5601,7 @@ snapshots:
 
   vitest-browser-react@1.0.1(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(@vitest/browser@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4):
     dependencies:
-      '@vitest/browser': 3.2.4(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))(playwright@1.55.1)(vite@7.1.5(@types/node@20.19.14)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))(playwright@1.56.1)(vite@7.1.5(@types/node@20.19.14)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       vitest: 3.2.4(@types/node@20.19.14)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))
@@ -5636,7 +5636,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.14
-      '@vitest/browser': 3.2.4(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))(playwright@1.55.1)(vite@7.1.5(@types/node@20.19.14)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.11.2(@types/node@20.19.14)(typescript@5.9.2))(playwright@1.56.1)(vite@7.1.5(@types/node@20.19.14)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)
     transitivePeerDependencies:
       - jiti
       - less

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 0.540.0(react@19.1.0)
       next:
         specifier: 15.4.6
-        version: 15.4.6(@babel/core@7.28.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.4.6(@babel/core@7.28.4)(@playwright/test@1.56.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -48,6 +48,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.2.2
         version: 2.2.2
+      '@playwright/test':
+        specifier: ^1.56.1
+        version: 1.56.1
       '@tailwindcss/postcss':
         specifier: ^4.1.12
         version: 4.1.13
@@ -762,6 +765,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.56.1':
+    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3395,6 +3403,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.56.1':
+    dependencies:
+      playwright: 1.56.1
+
   '@polka/url@1.0.0-next.29': {}
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.13)(react@19.1.0)':
@@ -4897,7 +4909,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.4.6(@babel/core@7.28.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.4.6(@babel/core@7.28.4)(@playwright/test@1.56.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.4.6
       '@swc/helpers': 0.5.15
@@ -4915,6 +4927,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.4.6
       '@next/swc-win32-arm64-msvc': 15.4.6
       '@next/swc-win32-x64-msvc': 15.4.6
+      '@playwright/test': 1.56.1
       sharp: 0.34.3
     transitivePeerDependencies:
       - '@babel/core'

--- a/frontend/src/app/api/shuffle/route.ts
+++ b/frontend/src/app/api/shuffle/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+const SORT_NUMBER = 0.5;
+
+export async function POST(request: Request) {
+  const { members } = (await request.json()) as { members: string[] };
+  const result = members.sort(() => Math.random() - SORT_NUMBER);
+  return NextResponse.json({ members: result });
+}

--- a/frontend/src/app/form/form.tsx
+++ b/frontend/src/app/form/form.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+export function ShuffleMemberForm() {
+  // 結果
+  const [result, setResult] = useState([] as string[]);
+  // 要素への参照
+  const firstRef = useRef<HTMLInputElement>(null);
+  const secondRef = useRef<HTMLInputElement>(null);
+  const thirdRef = useRef<HTMLInputElement>(null);
+
+  // 通信
+  const callApi = useCallback(async () => {
+    const members = [] as string[];
+    const refs = [firstRef, secondRef, thirdRef];
+    for (const ref of refs) {
+      if (ref.current?.value) {
+        members.push(ref.current?.value);
+      }
+    }
+    const res = await fetch("/api/shuffle", {
+      method: "post",
+      body: JSON.stringify({ members }),
+    });
+    if (res.ok) {
+      const apiResponse = (await res.json()) as { members: string[] };
+      setResult(apiResponse.members);
+    }
+  }, []);
+
+  return (
+    <>
+      <label htmlFor="first">1人目:</label>
+      <input
+        id="first"
+        name="first"
+        placeholder="1人目の名前を入力"
+        ref={firstRef}
+        type="text"
+      />
+      <br />
+      <label htmlFor="second">2人目:</label>
+      <input
+        id="second"
+        name="second"
+        placeholder="2人目の名前を入力"
+        ref={secondRef}
+        type="text"
+      />
+      <br />
+      <label htmlFor="third">3人目:</label>
+      <input
+        id="third"
+        name="third"
+        placeholder="3人目の名前を入力"
+        ref={thirdRef}
+        type="text"
+      />
+      <br />
+      <button onClick={callApi} type="button">
+        シャッフル
+      </button>
+      <br />
+      <label htmlFor="result">結果</label>
+      <br />
+      <output htmlFor="first second third fourth" id="result">
+        {result.join("→")}
+      </output>
+    </>
+  );
+}

--- a/frontend/src/app/form/page.tsx
+++ b/frontend/src/app/form/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { ShuffleMemberForm } from "./form";
+
+export const metadata: Metadata = {
+  title: "入力フォーム",
+  description: "Playwrightハンズオンの第2のステップ",
+};
+
+export default function Form() {
+  return (
+    <main>
+      <h1>入力フォーム</h1>
+      <ShuffleMemberForm />
+    </main>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -30,8 +30,12 @@ export default function RootLayout({
         <TanstackProvider>
           <MswProvider>
             <ul>
-              <li><a href="/">ホーム</a></li>
-              <li><a href="/form">入力フォーム</a></li>
+              <li>
+                <a href="/">ホーム</a>
+              </li>
+              <li>
+                <a href="/form">入力フォーム</a>
+              </li>
             </ul>
             {children}
           </MswProvider>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -28,7 +28,13 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <TanstackProvider>
-          <MswProvider>{children}</MswProvider>
+          <MswProvider>
+            <ul>
+              <li><a href="/">ホーム</a></li>
+              <li><a href="/form">入力フォーム</a></li>
+            </ul>
+            {children}
+          </MswProvider>
         </TanstackProvider>
       </body>
     </html>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,95 +1,18 @@
-import Image from "next/image";
-import styles from "./page.module.css";
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '最初のページ',
+  description: 'Playwrightハンズオンの最初のステップ',
+  }
 
 export default function Home() {
   return (
-    <div className={styles.page}>
-      <main className={styles.main}>
-        <Image
-          alt="Next.js logo"
-          className={styles.logo}
-          height={38}
-          priority
-          src="/next.svg"
-          width={180}
-        />
-        <ol>
-          <li>
-            Get started by editing <code>src/app/page.tsx</code>.
-          </li>
-          <li>Save and see your changes instantly.</li>
-        </ol>
-
-        <div className={styles.ctas}>
-          <a
-            className={styles.primary}
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <Image
-              alt="Vercel logomark"
-              className={styles.logo}
-              height={20}
-              src="/vercel.svg"
-              width={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className={styles.secondary}
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className={styles.footer}>
-        <a
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Image
-            alt="File icon"
-            aria-hidden
-            height={16}
-            src="/file.svg"
-            width={16}
-          />
-          Learn
-        </a>
-        <a
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Image
-            alt="Window icon"
-            aria-hidden
-            height={16}
-            src="/window.svg"
-            width={16}
-          />
-          Examples
-        </a>
-        <a
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <Image
-            alt="Globe icon"
-            aria-hidden
-            height={16}
-            src="/globe.svg"
-            width={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
-  );
+    <main>
+      <h1>Playwrightのハンズオン</h1>
+      <p>あなたは1週間後にはE2Eテストのエキスパートです。</p>
+      <p>
+        <button>操作ボタン</button>
+      </p>
+    </main>
+  )
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,9 @@
-import type { Metadata } from 'next'
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: '最初のページ',
-  description: 'Playwrightハンズオンの最初のステップ',
-  }
+  title: "最初のページ",
+  description: "Playwrightハンズオンの最初のステップ",
+};
 
 export default function Home() {
   return (
@@ -11,8 +11,8 @@ export default function Home() {
       <h1>Playwrightのハンズオン</h1>
       <p>あなたは1週間後にはE2Eテストのエキスパートです。</p>
       <p>
-        <button>操作ボタン</button>
+        <button type="button">操作ボタン</button>
       </p>
     </main>
-  )
+  );
 }

--- a/frontend/tests/example.spec.ts
+++ b/frontend/tests/example.spec.ts
@@ -1,18 +1,20 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test('has title', async ({ page }) => {
-  await page.goto('https://playwright.dev/');
+test("has title", async ({ page }) => {
+  await page.goto("https://playwright.dev/");
 
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(/Playwright/);
 });
 
-test('get started link', async ({ page }) => {
-  await page.goto('https://playwright.dev/');
+test("get started link", async ({ page }) => {
+  await page.goto("https://playwright.dev/");
 
   // Click the get started link.
-  await page.getByRole('link', { name: 'Get started' }).click();
+  await page.getByRole("link", { name: "Get started" }).click();
 
   // Expects page to have a heading with the name of Installation.
-  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Installation" })
+  ).toBeVisible();
 });

--- a/frontend/tests/example.spec.ts
+++ b/frontend/tests/example.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Playwright/);
+});
+
+test('get started link', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Click the get started link.
+  await page.getByRole('link', { name: 'Get started' }).click();
+
+  // Expects page to have a heading with the name of Installation.
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+});

--- a/frontend/tests/form.spec.ts
+++ b/frontend/tests/form.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+test("ページの表示テスト", async ({ page }) => {
+  await page.goto("http://localhost:3000");
+  await page.getByRole("link", { name: "入力フォーム" }).click();
+  await expect(
+    page.getByRole("heading", { name: "入力フォーム" })
+  ).toBeVisible();
+  await expect(page).toHaveURL("http://localhost:3000/form");
+});
+
+test("フォーム操作のテスト", async ({ page }) => {
+  await page.goto("http://localhost:3000/form");
+  await page.getByRole("textbox", { name: /1人目/ }).fill("項羽");
+  await page.getByRole("textbox", { name: /2人目/ }).fill("劉邦");
+  await page.getByRole("button", { name: /シャッフル/ }).click();
+  await expect(page.getByRole("status", { name: /結果/ })).toHaveText(
+    /(項羽→劉邦)|(劉邦→項羽)/
+  );
+});
+
+test("フォーム操作のテスト(サーバーモック)", async ({ page }) => {
+  await page.route("/api/shuffle", async (route) => {
+    const json = [{ members: ["張飛", "関羽", "劉備"] }];
+    await route.fulfill({ json });
+  });
+
+  await page.goto("http://localhost:3000/form");
+  await page.getByRole("textbox", { name: /1人目/ }).fill("劉備");
+  await page.getByRole("textbox", { name: /2人目/ }).fill("関羽");
+  await page.getByRole("textbox", { name: /3人目/ }).fill("張飛");
+  await page.getByRole("button", { name: /シャッフル/ }).click();
+  await expect(page.getByRole("status", { name: /結果/ })).toHaveText(
+    /張飛→関羽→劉備/
+  );
+});

--- a/frontend/tests/home.spec.ts
+++ b/frontend/tests/home.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test'
+
+test('ページの表示テスト', async ({page}) => {
+    await page.goto('http://localhost:3000')
+    await expect(page).toHaveTitle(/最初のページ/)
+    await expect(page.getByRole('heading')).toHaveText(/Playwrightのハンズオン/)
+    await expect(page.getByRole('button', {name: /操作ボタン/})).toBeVisible()
+})

--- a/frontend/tests/home.spec.ts
+++ b/frontend/tests/home.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect } from '@playwright/test'
+import { expect, test } from "@playwright/test";
 
-test('ページの表示テスト', async ({page}) => {
-    await page.goto('http://localhost:3000')
-    await expect(page).toHaveTitle(/最初のページ/)
-    await expect(page.getByRole('heading')).toHaveText(/Playwrightのハンズオン/)
-    await expect(page.getByRole('button', {name: /操作ボタン/})).toBeVisible()
-})
+test("ページの表示テスト", async ({ page }) => {
+  await page.goto("http://localhost:3000");
+  await expect(page).toHaveTitle(/最初のページ/);
+  await expect(page.getByRole("heading")).toHaveText(/Playwrightのハンズオン/);
+  await expect(page.getByRole("button", { name: /操作ボタン/ })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
Playwrightを使用したE2Eテスト環境を構築し、基本的なテストケースを実装しました。

- Playwrightのバージョンを1.56.1に更新し、`@playwright/test`パッケージを追加
- GitHub Actions上でのPlaywrightテスト実行ワークフローを追加
- テスト実例として、ホームページと入力フォームのE2Eテストを実装
- テスト用のサンプルページ（フォームとシャッフルAPI）を追加

## 主な変更内容

### テスト環境のセットアップ
- playwright.config.ts - Playwright設定ファイルを追加
- .github/workflows/playwright.yml - CI/CDワークフローを追加
- package.json - `@playwright/test@^1.56.1`と`playwright@^1.56.1`に更新
- biome.json - テストファイル用のlintルールを追加
- .gitignore - Playwright関連ファイルの除外設定を追加

### テストケースの実装
- tests/home.spec.ts - ホームページの基本的な表示テスト
- tests/form.spec.ts - フォーム操作とAPIモックのテスト
- tests/example.spec.ts - Playwrightの公式サンプルテスト

### テスト用のサンプル実装
- src/app/form/page.tsx - 入力フォームページ
- src/app/form/form.tsx - シャッフル機能を持つフォームコンポーネント
- src/app/api/shuffle/route.ts - メンバーをシャッフルするAPIエンドポイント
- src/app/layout.tsx - ナビゲーションリンクの追加
- src/app/page.tsx - ホームページの簡素化

## テスト実行方法

```bash
# テストの実行
pnpm exec playwright test

# テストレポートの確認
pnpm exec playwright show-report
```

## 備考
- E2Eテストのハンズオン用の実装例として、フォーム操作、API通信、モックの活用などの基本的なパターンを含んでいます
- CI上でも自動的にテストが実行されるよう設定されています

🤖 Generated with [Claude Code](https://claude.com/claude-code)